### PR TITLE
[update]:[README.md] Make the libraries in the Release directory copy to ~/.local/share/cef instead of the entire directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Use CEF in Rust.
 - Copy files to `.local`:
 
 ```
-cp -r Resources ~/.local/share/cef
-cp -r Release ~/.local/share/cef
+mkdir ~/.local/share/cef
+cp -r Resources/* ~/.local/share/cef
+cp -r Release/* ~/.local/share/cef
 ```
 
 - Build and run the application with `LD_LIBRARY_PATH` (or you can also add rpath to your cargo config or build script):

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,9 @@ Use CEF in Rust.
 - Copy files to `.local`:
 
 ```
-cp -r Resources ~/.local/share/cef
-cp -r Release ~/.local/share/cef
+mkdir ~/.local/share/cef
+cp -r Resources/* ~/.local/share/cef
+cp -r Release/* ~/.local/share/cef
 ```
 
 - Build and run the application with `LD_LIBRARY_PATH` (or you can also add rpath to your cargo config or build script):


### PR DESCRIPTION
Make the libraries in the Release directory copy to ~/.local/share/cef instead of the entire directory